### PR TITLE
Add import-linter to pre-commit hooks

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -1,6 +1,6 @@
 [importlinter]
 root_packages=
-    copywriter
+    src.copywriter
     tests
 
 include_external_packages=True
@@ -9,6 +9,6 @@ include_external_packages=True
 name = Application code should not import non-application code (i.e. tests, devtools)
 type = forbidden
 source_modules =
-    copywriter
+    src.copywriter
 forbidden_modules =
     tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,12 @@ repos:
         # Preserve markdown hard line breaks
         args: ["--markdown-linebreak-ext", "md"]
 
+  # Import-linter to check project structure
+  - repo: https://github.com/seddonym/import-linter/
+    rev: "v2.0"
+    hooks:
+      - id: import-linter
+
   # Ruff for linting
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: "v0.1.13"


### PR DESCRIPTION
Had to update the `.import-linter` configuration to accomodate the `src` structure.

See https://github.com/seddonym/import-linter/issues/214 for more details