### PR TITLE
Fix entrypoint cli testing issue on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,4 +63,10 @@ docs-serve:
 build:
 	poetry build
 
-ci: check-configs qa docs tests
+cli-checks:
+# Run the command line to make sure it works
+	poetry run python -m copywriter --help > /dev/null
+# Run the command line using the shortcut script
+	poetry run copywriter --help > /dev/null
+
+ci: check-configs qa docs tests cli-checks

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,7 +1,3 @@
-import subprocess
-import sys
-
-import pytest
 import semver
 from typer.testing import CliRunner
 
@@ -12,14 +8,6 @@ class TestCliApplication:
     """Collection of CLI tests."""
 
     runner = CliRunner()
-
-    @pytest.mark.xfail(
-        reason="Known bug when testing on Windows, see https://github.com/ValentinCalomme/copywriter/issues/12",
-        condition=sys.platform == "win32",
-    )
-    def test_entrypoint(self) -> None:
-        """Check that we can call the commandline directly."""
-        subprocess.run(["copywriter", "--help"], capture_output=True, text=True)  # noqa:S603,S607
 
     def test_help(self) -> None:
         """Check that the application's help command doesn't crash."""


### PR DESCRIPTION
Moved the testing from pytest to a command in the Makefile